### PR TITLE
Remove get_capabilities and register geocoding prompt

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/NERVsystems/osmmcp/pkg/osm"
 	"github.com/NERVsystems/osmmcp/pkg/tools"
+	"github.com/NERVsystems/osmmcp/pkg/tools/prompts"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -51,6 +53,17 @@ func NewServer() (*Server, error) {
 	// Create tool registry and register all tools and prompts
 	registry := tools.NewRegistry(logger)
 	registry.RegisterAll(srv)
+
+	// Register prompt templates so the AI knows how to use the tools
+	geocodingTemplate := mcp.NewPromptTemplate("geocoding",
+		[]mcp.PromptMessage{
+			mcp.NewPromptMessage(
+				mcp.RoleSystem,
+				mcp.NewTextContent(prompts.GeocodingSystemPrompt()),
+			),
+		},
+	)
+	srv.AddPromptTemplate(geocodingTemplate)
 
 	return &Server{
 		srv:    srv,

--- a/pkg/tools/health.go
+++ b/pkg/tools/health.go
@@ -36,25 +36,6 @@ type VersionInfo struct {
 	Settings    map[string]string `json:"settings,omitempty"`
 }
 
-// CapabilitiesInfo represents the capabilities of the service
-type CapabilitiesInfo struct {
-	Version string       `json:"version"`
-	Tools   []ToolInfo   `json:"tools"`
-	Prompts []PromptInfo `json:"prompts,omitempty"`
-}
-
-// ToolInfo represents information about a registered tool
-type ToolInfo struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-// PromptInfo represents information about a registered prompt
-type PromptInfo struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
-}
-
 // GetVersionTool returns a tool definition for retrieving version information
 func GetVersionTool() mcp.Tool {
 	return mcp.NewTool("get_version",
@@ -93,52 +74,6 @@ func HandleGetVersion(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	if err != nil {
 		logger.Error("failed to marshal version info", "error", err)
 		return ErrorResponse("Failed to retrieve version information"), nil
-	}
-
-	return mcp.NewToolResultText(string(resultBytes)), nil
-}
-
-// GetCapabilitiesTool returns a tool definition for retrieving capabilities
-func GetCapabilitiesTool() mcp.Tool {
-	return mcp.NewTool("get_capabilities",
-		mcp.WithDescription("Get the list of available tools and their descriptions"),
-	)
-}
-
-// HandleGetCapabilities implements capabilities information retrieval
-func HandleGetCapabilities(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	logger := slog.Default().With("tool", "get_capabilities")
-
-	// Get the registry
-	registry, ok := ctx.Value("registry").(*Registry)
-	if !ok || registry == nil {
-		// Fallback to creating a new registry if not available in context
-		logger.Info("registry not found in context, creating temporary registry")
-		registry = NewRegistry(logger)
-	}
-
-	// Get all tool definitions
-	toolDefs := registry.GetToolDefinitions()
-
-	// Create capabilities info
-	capabilities := CapabilitiesInfo{
-		Version: Version,
-		Tools:   make([]ToolInfo, 0, len(toolDefs)),
-	}
-
-	// Add all tools
-	for _, tool := range toolDefs {
-		capabilities.Tools = append(capabilities.Tools, ToolInfo{
-			Name:        tool.Name,
-			Description: tool.Description,
-		})
-	}
-
-	// Return result
-	resultBytes, err := json.Marshal(capabilities)
-	if err != nil {
-		logger.Error("failed to marshal capabilities info", "error", err)
-		return ErrorResponse("Failed to retrieve capabilities"), nil
 	}
 
 	return mcp.NewToolResultText(string(resultBytes)), nil

--- a/pkg/tools/prompts/geocoding.go
+++ b/pkg/tools/prompts/geocoding.go
@@ -8,6 +8,40 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+// geocodingSystemPromptText contains instructions for using the geocoding tools.
+const geocodingSystemPromptText = `You have access to geocoding tools that convert between addresses and coordinates.
+When using these tools:
+
+1. Format addresses clearly without parentheses, e.g., "Blue Temple Chiang Rai Thailand" instead of "Blue Temple (Wat Rong Suea Ten)"
+2. Always include city and country for international locations
+3. If geocoding fails, check the error message for suggestions and try with the suggested improvements
+4. Try progressive simplification when address lookups fail
+5. For reverse geocoding, ensure coordinates are in decimal form within valid ranges
+
+IMPORTANT ADDRESS FORMATTING EXAMPLES:
+✅ GOOD: "Blue Temple Chiang Rai Thailand"
+❌ BAD: "Blue Temple (Wat Rong Suea Ten)"
+
+✅ GOOD: "Eiffel Tower, Paris, France"
+❌ BAD: "Eiffel Tower"
+
+✅ GOOD: "Sydney Opera House, Sydney, Australia"
+❌ BAD: "The Opera House"
+
+ERROR HANDLING GUIDELINES:
+When you receive error responses from the geocoding tools:
+1. Parse the error message for the error code and suggestions
+2. Try the suggestions provided in the error
+3. If an address with parentheses fails, remove the parenthetical content
+4. If a landmark name fails, add city and country information
+5. Use the most specific, clear address format possible`
+
+// GeocodingSystemPrompt returns the system prompt text used for the geocoding
+// prompt template and GetPrompt handler.
+func GeocodingSystemPrompt() string {
+	return geocodingSystemPromptText
+}
+
 // RegisterGeocodingPrompts registers all geocoding-related prompts with the MCP server
 func RegisterGeocodingPrompts(s *server.MCPServer) {
 	// Register the main geocoding prompt
@@ -28,32 +62,7 @@ func RegisterGeocodingPrompts(s *server.MCPServer) {
 
 // GeocodingPromptHandler returns the main prompt for geocoding tools
 func GeocodingPromptHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-	systemPrompt := `You have access to geocoding tools that convert between addresses and coordinates. 
-When using these tools:
-
-1. Format addresses clearly without parentheses, e.g., "Blue Temple Chiang Rai Thailand" instead of "Blue Temple (Wat Rong Suea Ten)"
-2. Always include city and country for international locations 
-3. If geocoding fails, check the error message for suggestions and try with the suggested improvements
-4. Try progressive simplification when address lookups fail
-5. For reverse geocoding, ensure coordinates are in decimal form within valid ranges
-
-IMPORTANT ADDRESS FORMATTING EXAMPLES:
-✅ GOOD: "Blue Temple Chiang Rai Thailand" 
-❌ BAD: "Blue Temple (Wat Rong Suea Ten)"
-
-✅ GOOD: "Eiffel Tower, Paris, France"
-❌ BAD: "Eiffel Tower"
-
-✅ GOOD: "Sydney Opera House, Sydney, Australia" 
-❌ BAD: "The Opera House"
-
-ERROR HANDLING GUIDELINES:
-When you receive error responses from the geocoding tools:
-1. Parse the error message for the error code and suggestions
-2. Try the suggestions provided in the error
-3. If an address with parentheses fails, remove the parenthetical content
-4. If a landmark name fails, add city and country information
-5. Use the most specific, clear address format possible`
+	systemPrompt := GeocodingSystemPrompt()
 
 	return mcp.NewGetPromptResult(
 		"Geocoding Tool Usage Guidelines",

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -43,12 +43,6 @@ func (r *Registry) GetToolDefinitions() []ToolDefinition {
 			Tool:        GetVersionTool(),
 			Handler:     HandleGetVersion,
 		},
-		{
-			Name:        "get_capabilities",
-			Description: "Get the list of available tools and capabilities",
-			Tool:        GetCapabilitiesTool(),
-			Handler:     HandleGetCapabilities,
-		},
 
 		// Geocoding tools
 		{


### PR DESCRIPTION
## Summary
- drop `get_capabilities` tool and its data structs
- register a geocoding prompt template during server startup
- expose geocoding system prompt via `prompts.GeocodingSystemPrompt`
- clean comments

## Testing
- `gofmt -w pkg/tools/prompts/geocoding.go pkg/server/server.go pkg/tools/health.go pkg/tools/registry.go`