### PR TITLE
refactor osm util uses geo package

### DIFF
--- a/pkg/osm/README.md
+++ b/pkg/osm/README.md
@@ -18,9 +18,9 @@ The `osm` package contains reusable components for interacting with OpenStreetMa
 
 ### Functions
 
-* `NewClient()` - Returns a pre-configured HTTP client for OSM API requests with appropriate timeouts and connection pooling
-* `HaversineDistance()` - Calculates distances between geographic coordinates using the Haversine formula
-* `NewBoundingBox()` - Creates a new bounding box for geographic queries
+* `GetClient()` - Returns the global HTTP client for OSM API requests
+* `HaversineDistance()` - Calculates distances between geographic coordinates using the Haversine formula (available in the `geo` package)
+* `NewBoundingBox()` - Creates a new bounding box for geographic queries (available in the `geo` package)
 * `BoundingBox.ExtendWithPoint()` - Extends a bounding box to include a point
 * `BoundingBox.Buffer()` - Adds a buffer around a bounding box
 * `BoundingBox.String()` - Returns a formatted string representation of a bounding box for use in Overpass queries
@@ -35,13 +35,13 @@ The `osm` package contains reusable components for interacting with OpenStreetMa
 import "github.com/NERVsystems/osmmcp/pkg/osm"
 
 // Create an HTTP client
-client := osm.NewClient()
+client := osm.GetClient(context.Background())
 
 // Calculate distance between two points
-distance := osm.HaversineDistance(lat1, lon1, lat2, lon2)
+distance := geo.HaversineDistance(lat1, lon1, lat2, lon2)
 
 // Create and use a bounding box
-bbox := osm.NewBoundingBox()
+bbox := geo.NewBoundingBox()
 bbox.ExtendWithPoint(lat1, lon1)
 bbox.ExtendWithPoint(lat2, lon2)
 bbox.Buffer(1000) // Add 1000 meter buffer

--- a/pkg/osm/util.go
+++ b/pkg/osm/util.go
@@ -3,8 +3,6 @@ package osm
 
 import (
 	"fmt"
-	"net/http"
-	"time"
 
 	"github.com/NERVsystems/osmmcp/pkg/geo"
 )
@@ -21,32 +19,6 @@ const (
 	// Earth radius in meters (approximate) - re-exported from geo package
 	EarthRadius = geo.EarthRadius
 )
-
-// NewClient returns an HTTP client configured for OSM API requests
-// Deprecated: Use GetClient(ctx) instead for connection pooling
-func NewClient() *http.Client {
-	return &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			MaxIdleConns:        10,
-			MaxIdleConnsPerHost: 10,
-			MaxConnsPerHost:     10,
-			IdleConnTimeout:     30 * time.Second,
-		},
-	}
-}
-
-// HaversineDistance calculates the great-circle distance between two points
-// Deprecated: Use geo.HaversineDistance instead
-func HaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
-	return geo.HaversineDistance(lat1, lon1, lat2, lon2)
-}
-
-// NewBoundingBox creates a new empty bounding box
-// Deprecated: Use geo.NewBoundingBox instead
-func NewBoundingBox() *geo.BoundingBox {
-	return geo.NewBoundingBox()
-}
 
 // CategoryMap maps common category names to OSM tags
 var CategoryMap = map[string]map[string][]string{

--- a/pkg/tools/parking.go
+++ b/pkg/tools/parking.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/NERVsystems/osmmcp/pkg/core"
+	"github.com/NERVsystems/osmmcp/pkg/geo"
 	"github.com/NERVsystems/osmmcp/pkg/osm"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -309,7 +310,7 @@ func processParkingFacilities(elements []osm.OverpassElement, lat, lon float64, 
 		}
 
 		// Calculate distance
-		distance := osm.HaversineDistance(
+		distance := geo.HaversineDistance(
 			lat, lon,
 			elemLat, elemLon,
 		)

--- a/pkg/tools/places.go
+++ b/pkg/tools/places.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/NERVsystems/osmmcp/pkg/core"
+	"github.com/NERVsystems/osmmcp/pkg/geo"
 	"github.com/NERVsystems/osmmcp/pkg/osm"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -158,7 +159,7 @@ func HandleFindNearbyPlaces(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		}
 
 		// Calculate distance
-		distance := osm.HaversineDistance(
+		distance := geo.HaversineDistance(
 			lat, lon,
 			element.Lat, element.Lon,
 		)

--- a/pkg/tools/routes.go
+++ b/pkg/tools/routes.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/NERVsystems/osmmcp/pkg/cache"
 	"github.com/NERVsystems/osmmcp/pkg/core"
+	"github.com/NERVsystems/osmmcp/pkg/geo"
 	"github.com/NERVsystems/osmmcp/pkg/osm"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -265,7 +266,7 @@ func HandleSuggestMeetingPoint(ctx context.Context, req mcp.CallToolRequest) (*m
 	// Calculate appropriate search radius based on distance between furthest points
 	var maxDistance float64
 	for _, loc := range locations {
-		dist := osm.HaversineDistance(centerLat, centerLon, loc.Latitude, loc.Longitude)
+		dist := geo.HaversineDistance(centerLat, centerLon, loc.Latitude, loc.Longitude)
 		if dist > maxDistance {
 			maxDistance = dist
 		}
@@ -343,7 +344,7 @@ func HandleSuggestMeetingPoint(ctx context.Context, req mcp.CallToolRequest) (*m
 	for _, place := range placesOutput.Places {
 		var totalDistance float64
 		for _, loc := range locations {
-			dist := osm.HaversineDistance(
+			dist := geo.HaversineDistance(
 				place.Location.Latitude, place.Location.Longitude,
 				loc.Latitude, loc.Longitude,
 			)

--- a/pkg/tools/schools.go
+++ b/pkg/tools/schools.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/NERVsystems/osmmcp/pkg/geo"
 	"github.com/NERVsystems/osmmcp/pkg/osm"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -190,7 +191,7 @@ func HandleFindSchoolsNearby(ctx context.Context, req mcp.CallToolRequest) (*mcp
 		}
 
 		// Calculate distance
-		distance := osm.HaversineDistance(
+		distance := geo.HaversineDistance(
 			latitude, longitude,
 			lat, lon,
 		)

--- a/pkg/tools/specialized_ev.go
+++ b/pkg/tools/specialized_ev.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/NERVsystems/osmmcp/pkg/geo"
 	"github.com/NERVsystems/osmmcp/pkg/osm"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -227,7 +228,7 @@ func HandleFindChargingStations(ctx context.Context, req mcp.CallToolRequest) (*
 		}
 
 		// Calculate distance
-		distance := osm.HaversineDistance(
+		distance := geo.HaversineDistance(
 			lat, lon,
 			element.Lat, element.Lon,
 		)
@@ -440,7 +441,7 @@ func HandleFindRouteChargingStations(ctx context.Context, req mcp.CallToolReques
 	}
 
 	// Create a bounding box for the route
-	bbox := osm.NewBoundingBox()
+	bbox := geo.NewBoundingBox()
 	for _, coord := range routeCoords {
 		bbox.ExtendWithPoint(coord.Latitude, coord.Longitude)
 	}
@@ -522,7 +523,7 @@ func HandleFindRouteChargingStations(ctx context.Context, req mcp.CallToolReques
 
 		// Simple but not super efficient algorithm to find closest point on route
 		for i := 0; i < len(routeCoords); i++ {
-			dist := osm.HaversineDistance(stationLoc.Latitude, stationLoc.Longitude,
+			dist := geo.HaversineDistance(stationLoc.Latitude, stationLoc.Longitude,
 				routeCoords[i].Latitude, routeCoords[i].Longitude)
 
 			if dist < minDistToRoute {
@@ -531,7 +532,7 @@ func HandleFindRouteChargingStations(ctx context.Context, req mcp.CallToolReques
 				// Calculate approximate distance from start to this point on route
 				if i > 0 {
 					for j := 0; j < i; j++ {
-						distFromStart += osm.HaversineDistance(
+						distFromStart += geo.HaversineDistance(
 							routeCoords[j].Latitude, routeCoords[j].Longitude,
 							routeCoords[j+1].Latitude, routeCoords[j+1].Longitude)
 					}


### PR DESCRIPTION
## Summary
- update utilities to use `geo` package distance and bounding box functions
- drop deprecated helpers from OSM util package
- update tooling to use new imports
- refresh docs with new package references

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: no route to host)*