### PR TITLE
Ensure server exits when stdin closes

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -98,6 +98,10 @@ func (s *Server) Run() error {
 		if err != nil && err != io.EOF {
 			s.logger.Error("server error", "error", err)
 		}
+
+		// Ensure the main Run loop is notified that the
+		// server has finished processing.
+		s.Shutdown()
 	}()
 
 	// Wait for stop signal


### PR DESCRIPTION
## Summary
- automatically shutdown when ServeStdio returns

## Testing
- `go test ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b41d406288324804e3ad49fbc0ab4