### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Potential fix for [https://github.com/NERVsystems/osmmcp/security/code-scanning/1](https://github.com/NERVsystems/osmmcp/security/code-scanning/1)

To fix the issue, we need to explicitly define permissions for the `build` job in the workflow file. Since the `build` job does not require write access to the repository or other GitHub features, we can set its permissions to `contents: read`. This ensures the job has only the minimal access required to perform its tasks.

The changes will be made in the `.github/workflows/go.yml` file:
1. Add a `permissions` block under the `build` job with `contents: read`.
2. Ensure no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
