### PR TITLE
Force HTTPS check

### DIFF
--- a/pkg/server/http_transport.go
+++ b/pkg/server/http_transport.go
@@ -419,6 +419,14 @@ func (t *HTTPTransport) Start() error {
 		IdleTimeout:  120 * time.Second,
 	}
 
+	// Validate ForceHTTPS configuration - TLS certificates must be provided
+	if t.config.ForceHTTPS && (t.config.TLSCertFile == "" || t.config.TLSKeyFile == "") {
+		t.mu.Unlock()
+		return core.NewError(core.ErrInvalidParameter,
+			"ForceHTTPS requires TLSCertFile and TLSKeyFile").
+			WithGuidance("Provide TLS certificates or disable ForceHTTPS")
+	}
+
 	// Check if TLS is configured
 	if t.config.TLSCertFile != "" && t.config.TLSKeyFile != "" {
 		t.logger.Info("starting HTTPS transport",


### PR DESCRIPTION
## Summary
- validate ForceHTTPS configuration in HTTP transport startup
- add unit test covering ForceHTTPS without TLS

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `golangci-lint run ./...` *(fails: can't run linter goanalysis_metalinter)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6881b75ee9688324aff516f160f4f7d7