### PR TITLE
fix: correct build directory path in server integration test

### DIFF
--- a/cmd/osmmcp/server_integration_test.go
+++ b/cmd/osmmcp/server_integration_test.go
@@ -41,7 +41,6 @@ func TestServerMainHealth(t *testing.T) {
 	binDir := t.TempDir()
 	binPath := filepath.Join(binDir, "osmmcp-test")
 	buildCmd := exec.Command("go", "build", "-o", binPath, ".")
-	buildCmd.Dir = "./cmd/osmmcp"
 	if out, err := buildCmd.CombinedOutput(); err != nil {
 		t.Fatalf("build failed: %v\n%s", err, out)
 	}


### PR DESCRIPTION
## Summary
- Fixed incorrect build directory path in TestServerMainHealth that was causing test failures
- The test was trying to change to `./cmd/osmmcp` when it was already in the correct directory

## Test plan
- [x] Run `go test ./cmd/osmmcp/...` locally - all tests pass
- [x] Run full test suite `go test -v ./...` - all tests pass
- [x] Build binary successfully with `go build -o osmmcp ./cmd/osmmcp`

🤖 Generated with [Claude Code](https://claude.ai/code)