### PR TITLE
fix(places): OR-match multi-value categories in find_nearby_places

### DIFF
--- a/pkg/tools/places.go
+++ b/pkg/tools/places.go
@@ -77,12 +77,13 @@ func HandleFindNearbyPlaces(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		WithTimeout(25).
 		WithCenter(lat, lon, radius)
 
-	// Add tag filters if category specified
+	// Add tag filters if category specified.
+	// Pass all values for a key in ONE WithTag call so the builder emits an OR-regex
+	// ([amenity~"restaurant|cafe|..."]). Calling WithTag once per value instead emits
+	// [amenity=restaurant][amenity=cafe]... which AND-matches and always returns empty.
 	if len(osmTags) > 0 {
 		for key, values := range osmTags {
-			for _, value := range values {
-				queryBuilder.WithTag(key, value)
-			}
+			queryBuilder.WithTag(key, values...)
 		}
 	}
 


### PR DESCRIPTION
## Problem

`find_nearby_places` returns `{"places":[]}` for any category that maps to **multiple** OSM tag values — which includes most of the common ones (`restaurant`, `cafe`, `healthcare`, `finance`, `transport`, ...). It reproduces everywhere, including dense city centers, so the tool effectively can't find restaurants at all.

## Root cause

The handler builds the Overpass query by calling `WithTag(key, value)` once per value:

```go
for key, values := range osmTags {
    for _, value := range values {
        queryBuilder.WithTag(key, value)
    }
}
```

Each `WithTag` appends a separate tag filter, and `buildElementFilter` concatenates them, so they are **AND-ed**:

```
node(around:2000,...)[amenity=restaurant][amenity=cafe][amenity=fast_food][amenity=bar][amenity=pub][amenity=food_court];
```

No single element can have `amenity` equal to six values at once, so the result set is always empty.

## Fix

Pass all values for a key in one variadic `WithTag(key, values...)` call. The builder's existing multi-value path then emits the intended OR-regex — and this matches the usage example already documented in `pkg/core/overpass.go` (`WithTag("amenity", "restaurant", "cafe")`):

```
node(around:2000,...)[amenity~"restaurant|cafe|fast_food|bar|pub|food_court"];
```

## Verification (manual, against live Overpass via the MCP server)

`find_nearby_places{category:"restaurant"}`:

| Location | Before | After |
|---|---|---|
| Gdańsk old town (54.3486, 18.6536, r=800) | 0 | 6 (Hard Rock Cafe, Piwnica Rajców, …) |
| Gdańsk / Stogi (54.3629, 18.7083, r=3000) | 0 | 6 (Bar Caira, ControlFood, …) |

Single-value categories (e.g. `pharmacy`) were unaffected before and after.
